### PR TITLE
Solution for #163

### DIFF
--- a/src/app/modules/core/dialogs/upload/upload.dialog.ts
+++ b/src/app/modules/core/dialogs/upload/upload.dialog.ts
@@ -145,12 +145,19 @@ export class UploadDialog {
     }
 
     showReturnOptions() {
-        document.getElementById("return-options").classList.remove("hidden");
-        document.getElementById("upload-progress-bar").classList.add("hidden");
-        document.getElementById("return-options").classList.add("return-options");
-        if (this.uploadFailed) {
-            document.getElementById("upload-status").classList.add("failed-upload");
-            document.getElementById("helpEnviroment").classList.remove("hidden");
+        try {
+            document.getElementById("return-options").classList.remove("hidden");
+            document.getElementById("upload-progress-bar").classList.add("hidden");
+            document.getElementById("return-options").classList.add("return-options");
+            if (this.uploadFailed) {
+                document.getElementById("upload-status").classList.add("failed-upload");
+                document.getElementById("helpEnviroment").classList.remove("hidden");
+            }
+        } catch (error) {
+            console.error(error);
+            console.warn("Failed to show action buttons on build-in dialog, using native alert() function!");
+            alert(this.statusMessage);
+            this.returnBlockEnvironment();
         }
     }
 
@@ -165,8 +172,13 @@ export class UploadDialog {
     }
 
     onError(error: string) {
-        document.getElementById("error-message").innerText = error;
-        document.getElementById("error-message").classList.remove("hidden");
-        this.uploadFailed = true;
+        try {
+            document.getElementById("error-message").innerText = error;
+            document.getElementById("error-message").classList.remove("hidden");
+            this.uploadFailed = true;
+        } catch (error) {
+            console.error(error);
+            console.warn("Failed to show error message string in build-in dialog!");
+        }
     }
 }


### PR DESCRIPTION
Dit is een simpele fix voor #163 .

Het probleem blijkt te zijn dat in sommige situaties als `showReturnOptions()` word gecalled de popup nog niet is verschenen en `document.getElementById()` de elements niet kan vinden, waardoor er geen changes op de classes kunnen worden uitgevoerd.

Deze error komt uit firefox's console (veroorzaakt doordat firefox geen serial ondersteunt).
```
TypeError: document.getElementById(...) is null
    showReturnOptions main.js:38
    jo main.js:38
    g main.js:1
    ZoneAwarePromise Angular
    g main.js:1
    startUpload main.js:36
    e main.js:36
    fac main.js:38
    Angular 5
main.js:38:1012
```

Ik heb dit voor nu opgelost door als dit het geval is de browser's native `alert()` function met een call naar `this.returnBlockEnvironment()` te gebruiken.

Ik heb het gevoel dat dit een tijdelijke fix is, maar het werkt voor nu in ieder geval om te voorkomen dat je elke keer de page moet refreshen als dit gebeurt omdat de popup niet afsluitbaar is...