### PR TITLE
fix: remove false negative on playwright test

### DIFF
--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -53,7 +53,7 @@ test('Double robot selection', async ({ page }) => {
 	await expect(page.getByText('Original Uno')).toBeHidden();
 
 	// For some reason it only happens the second time after entering. so reload the page.
-	page.reload();
+	await page.reload();
 
 	await page.getByText('Leaphy Original').click();
 	await page.getByText('Original Uno').click();


### PR DESCRIPTION
This fixes the issue with a playwright test giving false negatives.

This was caused by forgetting to use `await` on `page.reload()`.
When the test ends before the page fully reloaded it would not complete reloading, and thus would fail.
This is possible because the elements required for the rest of the test are loaded before other elements that are taking longer.